### PR TITLE
Feature/multicall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,7 +2108,7 @@ checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "liq-bot"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "cacache",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liq-bot"
-version = "0.1.7"
+version = "0.1.8"
 license = "MIT"
 authors = ["Rodrigo Bronzelle <bronzelle@gmail.com>", "danilo neves cruz <cruzdanilo@gmail.com>"]
 edition = "2021"

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,33 @@ impl Default for Config {
             .parse::<u64>()
             .expect("CHAIN_ID is not number");
 
+        let (chain_id_name, rpc_provider, rpc_provider_relayer) = match chain_id {
+            1 => {
+                dotenv::from_filename(".env.mainnet").ok();
+                (
+                    "mainnet",
+                    get_env_or_throw("MAINNET_NODE"),
+                    get_env_or_throw("MAINNET_NODE_RELAYER"),
+                )
+            }
+            5 => {
+                dotenv::from_filename(".env.goerli").ok();
+                (
+                    "goerli",
+                    get_env_or_throw("GOERLI_NODE"),
+                    get_env_or_throw("GOERLI_NODE_RELAYER"),
+                )
+            }
+            1337 => (
+                "fork",
+                get_env_or_throw("FORK_NODE"),
+                get_env_or_throw("FORK_NODE_RELAYER"),
+            ),
+            _ => {
+                panic!("Unknown network!")
+            }
+        };
+
         let wallet = MnemonicBuilder::<English>::default()
             .phrase(env::var("MNEMONIC").unwrap().as_str())
             .build()
@@ -43,27 +70,6 @@ impl Default for Config {
             .unwrap_or_else(|_| "0".into())
             .parse::<u32>()
             .unwrap_or(0);
-
-        let (chain_id_name, rpc_provider, rpc_provider_relayer) = match chain_id {
-            1 => (
-                "mainnet",
-                get_env_or_throw("MAINNET_NODE"),
-                get_env_or_throw("MAINNET_NODE_RELAYER"),
-            ),
-            5 => (
-                "goerli",
-                get_env_or_throw("GOERLI_NODE"),
-                get_env_or_throw("GOERLI_NODE_RELAYER"),
-            ),
-            1337 => (
-                "fork",
-                get_env_or_throw("FORK_NODE"),
-                get_env_or_throw("FORK_NODE_RELAYER"),
-            ),
-            _ => {
-                panic!("Unknown network!")
-            }
-        };
 
         let token_pairs = env::var("TOKEN_PAIRS").unwrap_or_else(|_| "".into());
 

--- a/src/exactly_events.rs
+++ b/src/exactly_events.rs
@@ -277,6 +277,8 @@ impl EthLogDecode for ExactlyEvents {
             "0x25d719d88a4512dd76c7442b910a83360845505894eb444ef299409e180f8fb9", // ConfigSet(uint32,uint64,address[],address[],uint8,uint64,bytes)
             "0x3ea16a923ff4b1df6526e854c9e3a995c43385d70e73359e10623c74f0b52037", // RoundRequested(address,bytes16,uint32,uint8)
             "0x78af32efdcad432315431e9b03d27e6cd98fb79c405fdc5af7c1714d9c0f75b3", // PayeeshipTransferred(address,address,address)
+            "0xed8889f560326eb138920d842192f0eb3dd22b4f139c87a2c57538e05bae1278", // OwnershipTransferRequested(address,address)
+            "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0", // OwnershipTransferred(address,address)
         ]
         .iter()
         .map(|x| H256::from_str(x).unwrap())

--- a/src/liquidation.rs
+++ b/src/liquidation.rs
@@ -80,7 +80,12 @@ pub struct Liquidation<M, W, S> {
     repay_offset: U256,
 }
 
-impl<M: 'static + Middleware, W: 'static + Middleware, S: 'static + Signer> Liquidation<M, W, S> {
+impl<
+        M: 'static + Middleware + Clone,
+        W: 'static + Middleware + Clone,
+        S: 'static + Signer + Clone,
+    > Liquidation<M, W, S>
+{
     pub fn new(
         client: Arc<SignerMiddleware<M, S>>,
         client_relay: Arc<SignerMiddleware<W, S>>,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1594,7 +1594,7 @@ impl<
                             },
                         );
                         info!(
-                            "{:<20?}: {:>20}{}",
+                            "{:<20?}: {:>24}{}",
                             address,
                             hf.as_ref().unwrap_or(&previewer_hf),
                             if hf.is_err() { "*" } else { "" }


### PR DESCRIPTION
- Multicall is just instantiated once, avoiding unnecessary calls;
- Cache is saved on paths related to the chains like: `cache/1/` or `cache/5/`;
- Env files specific for each chain like `.env.mainnet` can be created overriding `.env` variables;
- Update liquidation stats function for the newest ether-rs;
- Some small log adjusts